### PR TITLE
Add support for constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Available Filters:
 * `be_media_from_production_start_year` - Specify the Start Year
 * `be_media_from_production_directories` - Manually set the upload directories to use
 
+Available Constants:
+* `BE_MEDIA_FROM_PRODUCTION_URL` - Specify the Production URL
+* `BE_MEDIA_FROM_PRODUCTION_START_MONTH` - Specify the Start Month
+* `BE_MEDIA_FROM_PRODUCTION_START_YEAR` - Specify the Start Year
+
 ## Installation
 
 Option 1: In your theme or core functionality plugin, specify the Production URL. This will use the production server for ALL media. [Example](https://gist.github.com/billerickson/74b71dae3adccd2d478c77c5a5dbe00a)
@@ -37,3 +42,11 @@ Option 1: In your theme or core functionality plugin, specify the Production URL
 Option 2: In your theme or core functionality plugin, specify the Production URL and specific directories using the provided filters. [Example](https://gist.github.com/billerickson/d4365166ba004bb45e9a)
 
 Option 3: In your theme or core functionality plugin, specify the Production URL, Start Month and End Month using the provided filters. [Example](https://gist.github.com/billerickson/dd6639cc11e4464512e4)
+
+## Installation via WP-CLI and constants
+
+```
+wp config set BE_MEDIA_FROM_PRODUCTION_URL http://www.billerickson.net --type=constant
+wp config set BE_MEDIA_FROM_PRODUCTION_START_MONTH 01 --type=constant
+wp config set BE_MEDIA_FROM_PRODUCTION_START_YEAR 2016 --type=constant
+```

--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -5,7 +5,7 @@
  * Description: Uses local media when it's available, and uses the production server for rest.
  * Author:      Bill Erickson
  * Author URI:  http://www.billerickson.net
- * Version:     1.4.0
+ * Version:     1.5.0
  * Text Domain: be-media-from-production
  * Domain Path: languages
  *
@@ -110,8 +110,8 @@ class BE_Media_From_Production {
 	function get_upload_directories() {
 	
 		// Include all upload directories starting from a specific month and year
-		$month = str_pad( apply_filters( 'be_media_from_production_start_month', $this->start_month ), 2, 0, STR_PAD_LEFT );
-		$year = apply_filters( 'be_media_from_production_start_year', $this->start_year );
+		$month = str_pad( $this->get_start_month(), 2, 0, STR_PAD_LEFT );
+		$year = $this->get_start_year();
 	
 		$upload_dirs = array();
 
@@ -245,7 +245,7 @@ class BE_Media_From_Production {
 			return $image_url;
 		}
 		
-		$production_url = esc_url( apply_filters( 'be_media_from_production_url', $this->production_url ) );
+		$production_url = esc_url( $this->get_production_url() );
 		if( empty( $production_url ) )
 			return $image_url;
 	
@@ -265,7 +265,54 @@ class BE_Media_From_Production {
 			
 		return $image_url;
 	}
-	
+
+	/**
+	 * Return the production URL
+	 *
+	 * First, this method checks if constant `BE_MEDIA_FROM_PRODUCTION_URL`
+	 * exists and non-empty. Than applies a filter `be_media_from_production_url`.
+	 *
+	 * @since 1.5.0
+	 * @return string
+	 */
+	public function get_production_url() {
+		$production_url = $this->production_url;
+		if ( defined( 'BE_MEDIA_FROM_PRODUCTION_URL' ) && BE_MEDIA_FROM_PRODUCTION_URL ) {
+			$production_url = BE_MEDIA_FROM_PRODUCTION_URL;
+		}
+
+		return apply_filters( 'be_media_from_production_url', $production_url );
+	}
+
+	/**
+	 * Return start month
+	 *
+	 * @since 1.5.0
+	 * @return string
+	 */
+	public function get_start_month() {
+		$start_month = $this->start_month;
+		if ( defined( 'BE_MEDIA_FROM_PRODUCTION_START_MONTH' ) && BE_MEDIA_FROM_PRODUCTION_START_MONTH ) {
+			$start_month = BE_MEDIA_FROM_PRODUCTION_START_MONTH;
+		}
+
+		return apply_filters( 'be_media_from_production_start_month', $start_month );
+	}
+
+	/**
+	 * Return start year
+	 *
+	 * @since 1.5.0
+	 * @return string
+	 */
+	public function get_start_year() {
+		$start_year = $this->start_year;
+		if ( defined( 'BE_MEDIA_FROM_PRODUCTION_START_YEAR' ) && BE_MEDIA_FROM_PRODUCTION_START_YEAR ) {
+			$start_year = BE_MEDIA_FROM_PRODUCTION_START_YEAR;
+		}
+
+		return apply_filters( 'be_media_from_production_start_year', $start_year );
+	}
 }
 
 new BE_Media_From_Production;


### PR DESCRIPTION
This makes it easy to configure the plugin via constants in
wp-config.php

Also allows automating installation with WP-CLI without the need to edit your theme or plugin.

Available constants:
 - `BE_MEDIA_FROM_PRODUCTION_URL`
 - `BE_MEDIA_FROM_PRODUCTION_START_MONTH`
 - `BE_MEDIA_FROM_PRODUCTION_START_YEAR`