### PR TITLE
Don't update image urls that already start with the production_url

### DIFF
--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -249,9 +249,6 @@ class BE_Media_From_Production {
 		if( empty( $production_url ) )
 			return $image_url;
 	
-		if ( strpos( $image_url, $production_url ) === 0 )
-			return $image_url;
-		
 		$exists = false;
 		$upload_dirs = $this->directories;
 		if( $upload_dirs ) {		
@@ -263,7 +260,7 @@ class BE_Media_From_Production {
 		}
 				
 		if( ! $exists ) {
-			$image_url = str_replace( home_url(), $production_url, $image_url );
+			$image_url = str_replace( trailingslashit( home_url() ), trailingslashit( $production_url ), $image_url );
 		}
 			
 		return $image_url;

--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -249,6 +249,9 @@ class BE_Media_From_Production {
 		if( empty( $production_url ) )
 			return $image_url;
 	
+		if ( strpos( $image_url, $production_url ) === 0 )
+			return $image_url;
+		
 		$exists = false;
 		$upload_dirs = $this->directories;
 		if( $upload_dirs ) {		


### PR DESCRIPTION
I've run into an issue where URLs were replaced twice. 

This only happens if the home_url() matches the first part of the production URL, for example:
- `http://testproject` - **the home URL**
- `http://testproject.staging.testcompany.com` - **the production URL**

In this situation, image URLs can end up being replaced twice:
- URL to be replaced: 
`http://testproject/wp-content/uploads/2019/10/testimage.jpg`
- Incorrect URL after replacing:
`http://testproject.staging.testcompany.com.staging.testcompany.com/wp-content/uploads/2019/10/testimage.jpg`

This pull request fixes this problem by skipping the URL replacement if `$image_url` already starts with the `$production_url`.

After the fix, the above image URL is correctly replaced and will look like this:
- `http://testproject/wp-content/uploads/2019/10/testimage.jpg`