### PR TITLE
Add closing bracket to exclude list in regex

### DIFF
--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -129,7 +129,7 @@ class BE_Media_From_Production {
 	function image_content( $content ) {
 		$upload_locations = wp_upload_dir();
 
-		$regex = '/https?\:\/\/[^\" ]+/i';
+		$regex = '/https?\:\/\/[^\") ]+/i';
 		preg_match_all($regex, $content, $matches);
 
 		foreach( $matches[0] as $url ) {


### PR DESCRIPTION
Fixed #13 

If a Cover block is used the image is in an inline style e.g.
style="background-image:url(https://example.com/wp-content/uploads/2020/08/image.jpg)"
The regex was capturing the ) in the match i.e. https://example.com/wp-content/uploads/2020/08/image.jpg)
and this was breaking the site when the image file exists on the staging (non-production) site.