### PR TITLE
Correct base url of images

### DIFF
--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -240,7 +240,7 @@ class BE_Media_From_Production {
 		if( empty( $production_url ) )
 			return $image_url;
 
-		$image_url = str_replace( trailingslashit( home_url() ), trailingslashit( $production_url ), $image_url );
+		$image_url = str_replace( trailingslashit( site_url() ), trailingslashit( $production_url ), $image_url );
 		return $image_url;
 	}
 


### PR DESCRIPTION
This corrects a bug which prevents image replacements on some sites with WPML installed, and also on WordPress sites embedded in another site (WordPress or other)