### PR TITLE
Allow plugin to be updated when in the mu-plugins directory

### DIFF
--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -279,7 +279,10 @@ class BE_Media_From_Production {
 		$myUpdateChecker = YahnisElsts\PluginUpdateChecker\v5\PucFactory::buildUpdateChecker(
 			'https://github.com/billerickson/be-media-from-production',
 			__FILE__,
-			'be-media-from-production'
+			'be-media-from-production',
+			12,
+			'',
+			__FILE__
 		);
 		
 		//Set the branch that contains the stable release.


### PR DESCRIPTION
The first two added parameters are for the hours between checks (`12`) and the option name (`''`) and have been left at their defaults - which you used before. The third added parameter is specified as `__FILE__` to specify where the plugin file is so that updates work even when in the `mu-plugins` directory