### PR TITLE
feat: introduce new filter to make the local site url filterable

### DIFF
--- a/be-media-from-production.php
+++ b/be-media-from-production.php
@@ -257,8 +257,18 @@ class BE_Media_From_Production {
 		$production_url = esc_url( $this->get_production_url() );
 		if( empty( $production_url ) )
 			return $image_url;
-
-		$image_url = str_replace( trailingslashit( site_url() ), trailingslashit( $production_url ), $image_url );
+		
+	       /**
+		* Filters the home/site url of the local website
+		* 
+		* You can use this filter to modify the local site url if site_url() does not resolve to the actual website. This can be the case in a Bedrock based setup or similar.
+		*
+		* @param string $local_site_url the result of the site_url() function.
+		*
+		* @return string Updated local site url.
+		*/
+		$site_url  = apply_filters('be_media_from_production_local_site_url', site_url());
+ 		$image_url = str_replace(trailingslashit($site_url), trailingslashit($production_url), $image_url);
 		return $image_url;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,14 @@ add_filter( 'be_media_from_production_url', function() {
 });
 ```
 
+In case you are running Bedrock, wp-starter or similar, you can use the following filter to modify the base url of your local website to make sure the image replacement works.
+
+```
+add_filter( 'be_media_from_production_local_site_url', function() {
+	return home_url();
+});
+```
+
 **Installation via WP-CLI and constants**
 
 ```


### PR DESCRIPTION
In #26 the way the "base url" of the local site is being loaded changed from `home_url()` to `site_url()`. This fixed an issue in WPML but introduces an issue in Bedrock based setups. 

This PR introduces a filter called `be_media_from_production_local_site_url` to modify your local "base url" in your codebase. This way WPML still works out of the box, but other people have an option to modify the url when needed.

I have tested the code in a local Bedrock environment in combination with the filter I documented.